### PR TITLE
Fix crash when parsing empty files

### DIFF
--- a/Messages.md
+++ b/Messages.md
@@ -21,7 +21,7 @@ This document contains a detailed description of the messages from the Log Parse
     - [LP-8: Cannot serialize sample](#lp-8-cannot-serialize-sample)
     - [LP-13: Write maximum blocking time expired](#lp-13-write-maximum-blocking-time-expired)
     - [LP-14: Cannot write because DataWriter has been deleted](#lp-14-cannot-write-because-datawriter-has-been-deleted)
-    - [LP-15: Cannot delete X FlowControllers from delete_contained_entities](#lp-15-cannot-delete-x-flowcontrollers-from-deletecontainedentities)
+    - [LP-15: Cannot delete X FlowControllers from delete_contained_entities](#lp-15-cannot-delete-x-flowcontrollers-from-delete_contained_entities)
     - [LP-16: Cannot initialize Monitoring: string too long in the RS configuration](#lp-16-cannot-initialize-monitoring-string-too-long-in-the-rs-configuration)
     - [LP-17: Cannot deserialize sample](#lp-17-cannot-deserialize-sample)
     - [LP-18: Cannot match remote entity in topic 'X': Different type names found ('Y', 'Z')](#lp-18-cannot-match-remote-entity-in-topic-x-different-type-names-found-y-z-)

--- a/README.md
+++ b/README.md
@@ -98,10 +98,13 @@ Logger.get_instance().set_verbosity_by_category(
 
 * Environment variable `NDDS_QOS_PROFILES`. It is possible to specify an inline XML QoS profile inside the variable:
 ```bash
+# Bash
 export NDDS_QOS_PROFILES="str://\"<dds><qos_library name=\"myLoggingLib\"><qos_profile name=\"myLoggingProfile\" is_default_participant_factory_profile=\"true\"><participant_factory_qos><logging><verbosity>ALL</verbosity><category>ALL</category><print_format>TIMESTAMPED</print_format></logging></participant_factory_qos></qos_profile></qos_library></dds>\""
 
+# Tcsh
 setenv NDDS_QOS_PROFILES 'str://"<dds><qos_library name="myLoggingLib"><qos_profile name="myLoggingProfile" is_default_participant_factory_profile="true"><participant_factory_qos><logging><verbosity>ALL</verbosity><category>ALL</category><print_format>TIMESTAMPED</print_format></logging></participant_factory_qos></qos_profile></qos_library></dds>"'
 
+# Windows CMD
 set NDDS_QOS_PROFILES=str://"<dds><qos_library name="myLoggingLib"><qos_profile name="myLoggingProfile" is_default_participant_factory_profile="true"><participant_factory_qos><logging><verbosity>ALL</verbosity><category>ALL</category><print_format>TIMESTAMPED</print_format></logging></participant_factory_qos></qos_profile></qos_library></dds>"
 ```
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,10 @@ Logger.get_instance().set_verbosity_by_category(
 * Environment variable `NDDS_QOS_PROFILES`. It is possible to specify an inline XML QoS profile inside the variable:
 ```bash
 export NDDS_QOS_PROFILES="str://\"<dds><qos_library name=\"myLoggingLib\"><qos_profile name=\"myLoggingProfile\" is_default_participant_factory_profile=\"true\"><participant_factory_qos><logging><verbosity>ALL</verbosity><category>ALL</category><print_format>TIMESTAMPED</print_format></logging></participant_factory_qos></qos_profile></qos_library></dds>\""
+
+setenv NDDS_QOS_PROFILES 'str://"<dds><qos_library name="myLoggingLib"><qos_profile name="myLoggingProfile" is_default_participant_factory_profile="true"><participant_factory_qos><logging><verbosity>ALL</verbosity><category>ALL</category><print_format>TIMESTAMPED</print_format></logging></participant_factory_qos></qos_profile></qos_library></dds>"'
+
+set NDDS_QOS_PROFILES=str://"<dds><qos_library name="myLoggingLib"><qos_profile name="myLoggingProfile" is_default_participant_factory_profile="true"><participant_factory_qos><logging><verbosity>ALL</verbosity><category>ALL</category><print_format>TIMESTAMPED</print_format></logging></participant_factory_qos></qos_profile></qos_library></dds>"
 ```
 
 

--- a/logparser/devices/inputdevices.py
+++ b/logparser/devices/inputdevices.py
@@ -124,6 +124,9 @@ class InputFileDevice(InputDevice):
         # Based on @Greenstick's reply (https://stackoverflow.com/a/34325723)
         iteration = self.stream.tell()
         total = self.file_size
+        if total == 0:
+            return
+
         progress = 100.0 * iteration / total
         if self.progress > 0 and progress - self.progress < threshold:
             return

--- a/logparser/devices/inputdevices.py
+++ b/logparser/devices/inputdevices.py
@@ -128,7 +128,7 @@ class InputFileDevice(InputDevice):
             return
 
         progress = 100.0 * iteration / total
-        if self.progress > 0 and progress - self.progress < threshold:
+        if self.progress and progress - self.progress < threshold:
             return
 
         self.progress = progress


### PR DESCRIPTION
The script crashes when the user tried to give as input an empty file.
I have also fix some links in the *Messages.md* file and add two command line commands to increase verbosity from the command line in Windows and with tcsh.