### PR TITLE
Fix parser stopped to read input after empty line

### DIFF
--- a/logparser/devices/inputdevices.py
+++ b/logparser/devices/inputdevices.py
@@ -89,9 +89,12 @@ class InputConsoleDevice(InputDevice):
         line = None
         try:
             line = stdin.readline()
-        except Exception:  # pylint: disable=W0703
+            if line == "":  # On EOF it'll be empty, for empty line it's \n
+                line = None
+        except Exception as ex:  # pylint: disable=W0703
             # On error don't return None because we want to continue reading.
             line = ""
+            print("[InputError] %s" % ex)
 
         if self.show_progress:
             self.print_time(0.2)
@@ -147,9 +150,12 @@ class InputFileDevice(InputDevice):
         line = None
         try:
             line = self.stream.readline()
-        except Exception:  # pylint: disable=W0703
+            if line == "":  # On EOF it'll be empty, for empty line it's \n
+                line = None
+        except Exception as ex:  # pylint: disable=W0703
             # On error don't return None because we want to continue reading.
             line = ""
+            print("[InputError] %s" % ex)
 
         if self.show_progress:
             self.print_progress(0.01, 2, 51)

--- a/logparser/logparser.py
+++ b/logparser/logparser.py
@@ -156,11 +156,15 @@ class LogParser(object):
                                               True)
 
         # While there is a new line, parse it.
-        line = True  # For the first condition.
-        while line:
+        line = ""
+        while line is not None:
             # If the line contains non-UTF8 chars it could raise an exception.
             self.state['input_line'] += 1
-            line = device.read_line().rstrip("\r\n")
+            line = device.read_line()
+
+            # Remove end of lines
+            if line:
+                line = line.rstrip("\r\n")
 
             # If EOF or the line is empty, continue.
             if not line or line == "":

--- a/logparser/logparser.py
+++ b/logparser/logparser.py
@@ -166,8 +166,8 @@ class LogParser(object):
             if line:
                 line = line.rstrip("\r\n")
 
-            # If EOF or the line is empty, continue.
-            if not line or line == "":
+            # Skip if EOF or empty line
+            if not line:
                 continue
 
             # Write original log if needed


### PR DESCRIPTION
If the parser found an empty line it stopped reading more
input. The issue was that empty lines and EOF were similar.
As an empty line contains the new line characters (\n, \r\n),
we are using them to distinguish these two situations. The fix
applies to the InputFileDevice and InputConsoleDevice.

Fixes #16